### PR TITLE
chore: prepare 6.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 6.0.2
+
+- Require `convert_object: ^1.1.0` so the re-exported `tryGetRaw` and the updated `alternativeKeys` fallback (now selects the first non-null candidate) are always available.
+- Documented the `firstValueForKeys` → `tryGetRaw` migration in the [v6 migration guide](https://github.com/omar-hanafy/dart_helper_utils/blob/main/migration_guides.md).
+
 ## 6.0.1
 
 - Re-exported `package:collection/collection.dart` from `dart_helper_utils.dart`.

--- a/migration_guides.md
+++ b/migration_guides.md
@@ -88,9 +88,9 @@ map.getString('key', alternativeKeys: ['k2']);
 v5's public `Map.firstValueForKeys` is replaced by `Map.tryGetRaw` in
 [`convert_object`](https://pub.dev/packages/convert_object) (re-exported here).
 
-> **Requires `convert_object: ^1.1.0`.** `tryGetRaw` and the updated fallback
-> ship in convert_object 1.1.0. Make sure your resolved version is at least
-> 1.1.0 (for example run `dart pub upgrade convert_object`).
+> **Availability:** `tryGetRaw` and the updated `alternativeKeys` fallback ship
+> in `convert_object` 1.1.0. This version of `dart_helper_utils` already requires
+> `convert_object: ^1.1.0`, so upgrading pulls it in automatically.
 
 | v5 (Old)                                             | v6 (New)                                     |
 |:-----------------------------------------------------|:---------------------------------------------|

--- a/migration_guides.md
+++ b/migration_guides.md
@@ -83,6 +83,28 @@ map.getString('key', altKeys: ['k2']);
 map.getString('key', alternativeKeys: ['k2']);
 ```
 
+### 5.5. Raw value lookup: `firstValueForKeys` -> `tryGetRaw`
+
+v5's public `Map.firstValueForKeys` is replaced by `Map.tryGetRaw` in
+[`convert_object`](https://pub.dev/packages/convert_object) (re-exported here).
+
+> **Requires `convert_object: ^1.1.0`.** `tryGetRaw` and the updated fallback
+> ship in convert_object 1.1.0. Make sure your resolved version is at least
+> 1.1.0 (for example run `dart pub upgrade convert_object`).
+
+| v5 (Old)                                             | v6 (New)                                     |
+|:-----------------------------------------------------|:---------------------------------------------|
+| `map.firstValueForKeys('k')`                         | `map.tryGetRaw('k')`                         |
+| `map.firstValueForKeys('k', alternativeKeys: ['a'])` | `map.tryGetRaw('k', alternativeKeys: ['a'])` |
+
+For typed reads, prefer the typed getters (for example `map.tryGetString('k', alternativeKeys: ['a'])`).
+
+**Behavior change:** `alternativeKeys` now selects the first key whose value is
+**non-null** (like a `??` chain), not merely the first key that exists. A
+present-but-null alternative key no longer short-circuits the lookup. This
+affects every typed map getter that uses `alternativeKeys`. Use `Map.containsKey`
+if you must distinguish an absent key from a present-but-null one.
+
 ### 6. Removed Object Extensions
 The type-checking getters on `Object?` have been removed to keep the API clean. Use the `tryConvert` functions or standard Dart checks.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/omar-hanafy/dart_helper_utils
 homepage: https://github.com/omar-hanafy/dart_helper_utils
 issue_tracker: https://github.com/omar-hanafy/dart_helper_utils/issues
 documentation: https://pub.dev/documentation/dart_helper_utils/latest/
-version: 6.0.1
+version: 6.0.2
 
 topics:
   - utils
@@ -19,7 +19,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   collection: ^1.19.1
-  convert_object: ^1.0.4
+  convert_object: ^1.1.0
   equatable: ^2.0.8
   intl: ">=0.20.0 <1.0.0"
   meta: ^1.17.0


### PR DESCRIPTION
## Summary

Patch release **6.0.2**.

- Require `convert_object: ^1.1.0` so the re-exported `tryGetRaw` and the updated `alternativeKeys` fallback (now selects the first non-null candidate) are always available to consumers. The previous floor `^1.0.4` could resolve a `convert_object` without `tryGetRaw`.
- Document the `firstValueForKeys` -> `tryGetRaw` migration in the [v6 migration guide](https://github.com/omar-hanafy/dart_helper_utils/blob/main/migration_guides.md).

No `lib/` changes, so this is a patch bump. Public API is unchanged.

## Validation (local)

- `dart format` (check): clean
- `dart analyze`: No issues found
- `dart test`: 395 passed
- `dart pub publish --dry-run`: validates
- `pana`: 160/160

## Checklist

- [x] Full local validation checklist run (format, analyze, test, dry-run, pana)
- [x] pubspec.yaml version + CHANGELOG.md updated
- [x] Target branch lane respected (main = stable 6.0.2)