### PR TITLE
Add installable AI assistant plugin (Claude Code + Codex); release 6.0.3

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "dart-helper-utils-tools",
+  "interface": {
+    "displayName": "Dart Helper Utils Tools"
+  },
+  "plugins": [
+    {
+      "name": "dart-helper-utils",
+      "source": {
+        "source": "local",
+        "path": "./tooling/ai/dart-helper-utils"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "dart-helper-utils-tools",
+  "owner": {
+    "name": "Omar Hanafy"
+  },
+  "description": "AI coding-assistant plugins for the dart_helper_utils Dart package",
+  "plugins": [
+    {
+      "name": "dart-helper-utils",
+      "source": "./tooling/ai/dart-helper-utils",
+      "description": "Package-specific skills for the dart_helper_utils Dart package: exact utility APIs (strings, maps, collections, dates, intl formatting), async timing tools (Debouncer, throttle, stream transformers), the v5-to-v6 breaking migration, and version upgrades.",
+      "category": "developer-tools",
+      "tags": ["dart", "flutter", "utilities", "extensions", "debouncer"]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Analyze
         run: dart analyze
 
+      - name: Validate agent plugin
+        run: dart run tool/validate_agent_plugin.dart
+
       - name: Test
         run: dart test
 

--- a/.pubignore
+++ b/.pubignore
@@ -5,3 +5,11 @@ v6_proposals.md
 # Local artifacts and debug output.
 build/
 firebase-debug.log
+
+# AI coding-assistant plugin distribution (repo-hosted; pub.dev strips hidden
+# dirs, so shipping this tree would produce a broken partial plugin) and
+# maintainer-only files.
+tooling/
+tool/
+AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# dart_helper_utils - agent guide (maintainers)
+
+Pure-Dart utility package (no Flutter dependency). Public API is
+`lib/dart_helper_utils.dart`, which re-exports ALL of `package:collection`,
+ALL of `package:convert_object`, five intl symbols (`Bidi`, `BidiFormatter`,
+`DateFormat`, `Intl`, `NumberFormat`), and this package's own
+`lib/src/` tree (extensions, Debouncer/TimeUtils, raw_data constants).
+
+## Validation gates (run before claiming any change done)
+
+```bash
+dart format --output=none --set-exit-if-changed .
+dart analyze .                        # public_member_api_docs is enforced
+dart test
+dart run tool/validate_agent_plugin.dart   # AI plugin/marketplace consistency
+dart pub publish --dry-run            # must stay at 0 warnings
+```
+
+CI requires a PERFECT pana score on PRs ("CI / Pana" is a required check);
+avoid changes that cost points (missing doc comments, dependency issues,
+format drift).
+
+## Conventions
+
+- Conversion logic lives in the `convert_object` package, NOT here; do not
+  add conversion features to this repo (contribute upstream instead). The
+  same applies to string similarity (`string_search_algorithms`) and linked
+  lists (`doubly_linked_list`).
+- Any public API change needs matching tests in the flat `test/` directory
+  (one file per domain) and doc comments on every public member.
+- Behavior quirks are load-bearing: `Iterable.intersect` merges (union) on
+  purpose, `waitConcurrency`/`mapConcurrent` return completion order,
+  `daysInMonth` returns a padded calendar grid. Do not "fix" these without
+  a major release and a migration entry.
+- Never use the em-dash character in this repo's files; use '-' instead.
+
+## Release process
+
+1. Version bump lands via PR to `main` (branch protection requires checks
+   "CI / Test on stable", "CI / Pana", "pub-dry-run / dry-run"; no direct
+   pushes).
+2. `CHANGELOG.md` entry + `pubspec.yaml` version in the same PR.
+3. Merge -> auto-release workflow creates tag
+   `dart_helper_utils-vX.Y.Z` + GitHub release; the tag triggers trusted
+   publishing to pub.dev (OIDC, no manual credentials). Never re-use or
+   overwrite an existing tag.
+4. Breaking releases must update `migration_guides.md` AND ship the
+   corresponding migration hop in the AI plugin (see below) before tagging.
+
+## AI assistant plugin (Claude Code + Codex)
+
+- Canonical tree: `tooling/ai/dart-helper-utils/` (one shared `skills/`
+  set; manifests `.claude-plugin/plugin.json` + `.codex-plugin/plugin.json`).
+  Catalogs: `.claude-plugin/marketplace.json` and
+  `.agents/plugins/marketplace.json` at the repo root.
+- Both plugin manifests' `version` must equal the `pubspec.yaml` version -
+  bump them together (CI enforces via `tool/validate_agent_plugin.dart`).
+- Skill facts must match the source; when changing behavior in `lib/`,
+  update the affected skill/reference files in the same PR.
+- Any future BREAKING release must ship a migration hop in the plugin
+  (a dedicated `migrate-dart-helper-utils-vX-to-vY` skill for large
+  migrations, or a hop entry in `upgrade-dart-helper-utils`) before tagging.
+- The plugin tree, catalogs, `tool/`, and this file are excluded from the
+  pub.dev archive via `.pubignore` - keep the archive free of partial
+  plugin content. `migration_guides.md` stays IN the archive (linked from
+  the README).
+- The sibling `convert_object` repository hosts its own plugin
+  (`convert-object@convert-object-tools`) covering the conversion surface;
+  keep cross-references between the two consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## 6.0.3
+
+No Dart API changes.
+
+- Added an installable AI coding-assistant plugin for Claude Code and OpenAI
+  Codex, hosted in this repository (`tooling/ai/dart-helper-utils/`) with
+  four package-specific skills: exact utility-API usage, async/timing/stream
+  lifecycles (Debouncer, throttle, rateLimit, waitConcurrency), the v5-to-v6
+  breaking migration, and version-aware upgrades. Install via
+  `/plugin marketplace add omar-hanafy/dart_helper_utils` (Claude Code) or
+  `codex plugin marketplace add omar-hanafy/dart_helper_utils` (Codex CLI);
+  see the README's "AI coding-assistant support" section.
+- Added maintainer tooling: `tool/validate_agent_plugin.dart` (runs in CI)
+  keeps plugin manifests, marketplace catalogs, and skill metadata in sync
+  with the package version.
+- The plugin tree and maintainer files are excluded from the pub.dev archive
+  (`.pubignore`); the package payload is unchanged.
+
 ## 6.0.2
 
 - Require `convert_object: ^1.1.0` so the re-exported `tryGetRaw` and the updated `alternativeKeys` fallback (now selects the first non-null candidate) are always available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -10,6 +10,42 @@ and the APIs you already know from [`convert_object`](https://pub.dev/packages/c
 - Full API: https://pub.dev/documentation/dart_helper_utils/latest/dart_helper_utils/
 - Migration guide: https://github.com/omar-hanafy/dart_helper_utils/blob/main/migration_guides.md
 
+## AI coding-assistant support
+
+This repository ships a package-specific **agent plugin** for
+**Claude Code** and **OpenAI Codex** (this is tooling for coding agents, not
+a runtime feature of the Dart package). It teaches the agent the exact
+dart_helper_utils APIs - utility member names and semantics, the
+Debouncer/throttle/stream lifecycles, the v5-to-v6 breaking migration, and
+version-aware upgrades.
+
+Install in **Claude Code**:
+
+```
+/plugin marketplace add omar-hanafy/dart_helper_utils
+/plugin install dart-helper-utils@dart-helper-utils-tools
+```
+
+Install in **OpenAI Codex** (CLI; the IDE extension does not support
+plugins - use its `$skill-installer` there instead):
+
+```
+codex plugin marketplace add omar-hanafy/dart_helper_utils
+codex plugin add dart-helper-utils@dart-helper-utils-tools
+```
+
+Start a new agent session after installing so the skills load. Then try
+prompts like "debounce this search field with dart_helper_utils and clean it
+up on dispose" or "migrate this project from dart_helper_utils 5.x to 6.x",
+or invoke a skill explicitly in Claude Code, e.g.
+`/dart-helper-utils:use-dart-helper-utils`.
+
+The plugin is installed from this Git repository (not from the pub.dev
+archive), contains markdown skills only - no hooks, no MCP servers, no
+telemetry - and its version tracks the package version. Details, the full
+capability list, updating, and uninstalling are in
+[tooling/ai/dart-helper-utils/README.md](https://github.com/omar-hanafy/dart_helper_utils/blob/main/tooling/ai/dart-helper-utils/README.md).
+
 ## Installation
 
 ```yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/omar-hanafy/dart_helper_utils
 homepage: https://github.com/omar-hanafy/dart_helper_utils
 issue_tracker: https://github.com/omar-hanafy/dart_helper_utils/issues
 documentation: https://pub.dev/documentation/dart_helper_utils/latest/
-version: 6.0.2
+version: 6.0.3
 
 topics:
   - utils

--- a/tool/validate_agent_plugin.dart
+++ b/tool/validate_agent_plugin.dart
@@ -1,0 +1,355 @@
+/// Validates the AI coding-assistant plugin tree against this repository.
+///
+/// Deterministic checks (no network, no AI): manifest/catalog JSON syntax,
+/// version alignment with `pubspec.yaml`, kebab-case identifiers, skill
+/// frontmatter, self-contained skill references, absence of absolute or
+/// escaping paths, and pub archive exclusions in `.pubignore`.
+///
+/// Run from the repository root: `dart run tool/validate_agent_plugin.dart`.
+/// Exits non-zero when any check fails; prints every failure, not just the
+/// first.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+const _pluginRoot = 'tooling/ai/dart-helper-utils';
+const _claudeManifestPath = '$_pluginRoot/.claude-plugin/plugin.json';
+const _codexManifestPath = '$_pluginRoot/.codex-plugin/plugin.json';
+const _claudeCatalogPath = '.claude-plugin/marketplace.json';
+const _codexCatalogPath = '.agents/plugins/marketplace.json';
+const _skillsDir = '$_pluginRoot/skills';
+
+final _kebabCase = RegExp(r'^[a-z0-9]+(-[a-z0-9]+)*$');
+final _errors = <String>[];
+
+void _fail(String message) => _errors.add(message);
+
+String? _readPubspecVersion() {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    _fail('pubspec.yaml not found (run from the repository root).');
+    return null;
+  }
+  final match = RegExp(
+    r'^version:\s*(\S+)\s*$',
+    multiLine: true,
+  ).firstMatch(pubspec.readAsStringSync());
+  if (match == null) {
+    _fail('pubspec.yaml has no version line.');
+    return null;
+  }
+  return match.group(1);
+}
+
+Map<String, dynamic>? _readJson(String path) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    _fail('$path: missing file.');
+    return null;
+  }
+  try {
+    final decoded = jsonDecode(file.readAsStringSync());
+    if (decoded is! Map<String, dynamic>) {
+      _fail('$path: top-level JSON value must be an object.');
+      return null;
+    }
+    return decoded;
+  } on FormatException catch (e) {
+    _fail('$path: invalid JSON (${e.message}).');
+    return null;
+  }
+}
+
+void _checkSourcePath(String path, String owner) {
+  if (!path.startsWith('./')) {
+    _fail('$owner: source path "$path" must start with "./".');
+  }
+  if (path.contains('..')) {
+    _fail('$owner: source path "$path" must not contain "..".');
+  }
+  final resolved = path.startsWith('./') ? path.substring(2) : path;
+  if (!Directory(resolved).existsSync()) {
+    _fail('$owner: source path "$path" does not exist in the repository.');
+  }
+}
+
+void _checkManifests(String pubspecVersion) {
+  for (final entry in {
+    _claudeManifestPath: 'Claude',
+    _codexManifestPath: 'Codex',
+  }.entries) {
+    final manifest = _readJson(entry.key);
+    if (manifest == null) continue;
+    final name = manifest['name'];
+    if (name is! String || !_kebabCase.hasMatch(name)) {
+      _fail('${entry.key}: "name" must be a kebab-case string, got "$name".');
+    }
+    final version = manifest['version'];
+    if (version != pubspecVersion) {
+      _fail(
+        '${entry.key}: version "$version" does not match pubspec.yaml '
+        'version "$pubspecVersion".',
+      );
+    }
+    for (final field in ['description', 'license', 'repository']) {
+      if (manifest[field] is! String || (manifest[field] as String).isEmpty) {
+        _fail('${entry.key}: "$field" must be a non-empty string.');
+      }
+    }
+  }
+}
+
+void _checkCatalogs() {
+  final claude = _readJson(_claudeCatalogPath);
+  final codex = _readJson(_codexCatalogPath);
+  String? claudeName;
+  String? codexName;
+
+  if (claude != null) {
+    claudeName = claude['name'] as String?;
+    if (claudeName == null || !_kebabCase.hasMatch(claudeName)) {
+      _fail('$_claudeCatalogPath: marketplace "name" must be kebab-case.');
+    }
+    if (claude['owner'] is! Map || (claude['owner'] as Map)['name'] == null) {
+      _fail('$_claudeCatalogPath: "owner.name" is required.');
+    }
+    final plugins = claude['plugins'];
+    if (plugins is! List || plugins.isEmpty) {
+      _fail('$_claudeCatalogPath: "plugins" must be a non-empty array.');
+    } else {
+      final names = <String>{};
+      for (final plugin in plugins.cast<Map<String, dynamic>>()) {
+        final name = plugin['name'] as String?;
+        if (name == null || !_kebabCase.hasMatch(name)) {
+          _fail('$_claudeCatalogPath: plugin "name" must be kebab-case.');
+        } else if (!names.add(name)) {
+          _fail('$_claudeCatalogPath: duplicate plugin name "$name".');
+        }
+        final source = plugin['source'];
+        if (source is String) {
+          _checkSourcePath(source, '$_claudeCatalogPath ($name)');
+        } else {
+          _fail(
+            '$_claudeCatalogPath ($name): expected a relative-path string '
+            'source for a repo-hosted plugin.',
+          );
+        }
+        if (plugin.containsKey('version')) {
+          _fail(
+            '$_claudeCatalogPath ($name): do not set "version" in the '
+            'catalog entry; plugin.json is the single version source.',
+          );
+        }
+      }
+    }
+  }
+
+  if (codex != null) {
+    codexName = codex['name'] as String?;
+    if (codexName == null || !_kebabCase.hasMatch(codexName)) {
+      _fail('$_codexCatalogPath: marketplace "name" must be kebab-case.');
+    }
+    final plugins = codex['plugins'];
+    if (plugins is! List || plugins.isEmpty) {
+      _fail('$_codexCatalogPath: "plugins" must be a non-empty array.');
+    } else {
+      for (final plugin in plugins.cast<Map<String, dynamic>>()) {
+        final name = plugin['name'] as String?;
+        if (name == null || !_kebabCase.hasMatch(name)) {
+          _fail('$_codexCatalogPath: plugin "name" must be kebab-case.');
+        }
+        final source = plugin['source'];
+        if (source is Map<String, dynamic>) {
+          if (source['source'] != 'local') {
+            _fail(
+              '$_codexCatalogPath ($name): expected {"source": "local"} for '
+              'a repo-hosted plugin.',
+            );
+          }
+          final path = source['path'];
+          if (path is String) {
+            _checkSourcePath(path, '$_codexCatalogPath ($name)');
+          } else {
+            _fail('$_codexCatalogPath ($name): "source.path" is required.');
+          }
+        } else {
+          _fail('$_codexCatalogPath ($name): "source" must be an object.');
+        }
+      }
+    }
+  }
+
+  if (claudeName != null && codexName != null && claudeName != codexName) {
+    _fail(
+      'Marketplace names differ between catalogs: "$claudeName" (Claude) vs '
+      '"$codexName" (Codex). Keep them identical so install docs stay true.',
+    );
+  }
+}
+
+({String? name, String? description}) _parseFrontmatter(
+  String path,
+  String content,
+) {
+  final lines = const LineSplitter().convert(content);
+  if (lines.isEmpty || lines.first.trim() != '---') {
+    _fail('$path: missing YAML frontmatter opening "---".');
+    return (name: null, description: null);
+  }
+  final end = lines.indexWhere((l) => l.trim() == '---', 1);
+  if (end == -1) {
+    _fail('$path: frontmatter never closes with "---".');
+    return (name: null, description: null);
+  }
+  String? name;
+  String? description;
+  for (final line in lines.sublist(1, end)) {
+    if (line.startsWith('name:')) {
+      name = line.substring('name:'.length).trim();
+    } else if (line.startsWith('description:')) {
+      description = line.substring('description:'.length).trim();
+    }
+  }
+  return (name: name, description: description);
+}
+
+void _checkSkillLinks(String skillDir, String mdPath, String content) {
+  final links = RegExp(r'\[[^\]]*\]\(([^)]+)\)').allMatches(content);
+  for (final match in links) {
+    final target = match.group(1)!.split('#').first.trim();
+    if (target.isEmpty || target.contains('://')) continue;
+    if (target.startsWith('/')) {
+      _fail('$mdPath: absolute link target "$target" is not portable.');
+      continue;
+    }
+    final normalized = Uri(
+      path: '${File(mdPath).parent.path}/$target',
+    ).normalizePath().path;
+    if (!normalized.startsWith('$skillDir/')) {
+      _fail(
+        '$mdPath: link "$target" escapes the skill directory; skills must '
+        'be self-contained.',
+      );
+      continue;
+    }
+    if (!File(normalized).existsSync()) {
+      _fail('$mdPath: link target "$target" does not exist.');
+    }
+  }
+}
+
+void _checkSkills() {
+  final skillsRoot = Directory(_skillsDir);
+  if (!skillsRoot.existsSync()) {
+    _fail('$_skillsDir: missing skills directory.');
+    return;
+  }
+  final skillDirs = skillsRoot.listSync().whereType<Directory>().toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  if (skillDirs.isEmpty) {
+    _fail('$_skillsDir: no skills found.');
+    return;
+  }
+  final seen = <String>{};
+  for (final dir in skillDirs) {
+    final dirName = dir.path.split(Platform.pathSeparator).last;
+    final skillPath = '${dir.path}/SKILL.md';
+    final skillFile = File(skillPath);
+    if (!skillFile.existsSync()) {
+      _fail('$skillPath: missing SKILL.md.');
+      continue;
+    }
+    if (!_kebabCase.hasMatch(dirName)) {
+      _fail('${dir.path}: skill directory name must be kebab-case.');
+    }
+    if (!seen.add(dirName)) {
+      _fail('${dir.path}: duplicate skill name.');
+    }
+    final content = skillFile.readAsStringSync();
+    final frontmatter = _parseFrontmatter(skillPath, content);
+    if (frontmatter.name != dirName) {
+      _fail(
+        '$skillPath: frontmatter name "${frontmatter.name}" must equal the '
+        'directory name "$dirName" (agentskills.io requirement).',
+      );
+    }
+    final description = frontmatter.description;
+    if (description == null || description.isEmpty) {
+      _fail('$skillPath: frontmatter "description" is required.');
+    } else {
+      if (description.length > 1024) {
+        _fail(
+          '$skillPath: description is ${description.length} chars; the '
+          'portable limit is 1024.',
+        );
+      }
+      if (description.contains(': ') && !description.startsWith('"')) {
+        _fail(
+          '$skillPath: unquoted description contains ": " which breaks the '
+          'YAML plain scalar (frontmatter would silently drop). Rephrase or '
+          'quote the whole value.',
+        );
+      }
+    }
+    for (final md
+        in dir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.md'))) {
+      final text = md.readAsStringSync();
+      _checkSkillLinks(dir.path, md.path, text);
+      for (final marker in ['/Users/', '/home/', r'C:\']) {
+        if (text.contains(marker)) {
+          _fail('${md.path}: contains machine-specific path marker "$marker".');
+        }
+      }
+      for (final marker in ['-----BEGIN', 'ghp_', 'AKIA']) {
+        if (text.contains(marker)) {
+          _fail('${md.path}: contains secret-like marker "$marker".');
+        }
+      }
+    }
+  }
+}
+
+void _checkPubignore() {
+  final file = File('.pubignore');
+  if (!file.existsSync()) {
+    _fail('.pubignore: missing; the plugin tree would leak into the archive.');
+    return;
+  }
+  final lines = const LineSplitter()
+      .convert(file.readAsStringSync())
+      .map((l) => l.trim())
+      .toSet();
+  for (final required in ['tooling/', 'tool/', 'AGENTS.md', 'CLAUDE.md']) {
+    if (!lines.contains(required)) {
+      _fail(
+        '.pubignore: missing "$required" - the pub.dev archive must not '
+        'contain a partial AI plugin or maintainer-only files.',
+      );
+    }
+  }
+}
+
+/// Entry point; see the library docs for what is validated.
+void main() {
+  final pubspecVersion = _readPubspecVersion();
+  if (pubspecVersion != null) {
+    _checkManifests(pubspecVersion);
+  }
+  _checkCatalogs();
+  _checkSkills();
+  _checkPubignore();
+
+  if (_errors.isEmpty) {
+    stdout.writeln('Agent plugin validation passed.');
+    return;
+  }
+  stderr.writeln('Agent plugin validation FAILED:');
+  for (final error in _errors) {
+    stderr.writeln('  - $error');
+  }
+  exitCode = 1;
+}

--- a/tooling/ai/dart-helper-utils/.claude-plugin/plugin.json
+++ b/tooling/ai/dart-helper-utils/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "dart-helper-utils",
+  "displayName": "Dart Helper Utils",
+  "version": "6.0.3",
+  "description": "Package-specific skills for the dart_helper_utils Dart package: exact utility APIs (strings, maps, collections, dates, intl formatting), async timing tools (Debouncer, throttle, stream transformers), the v5-to-v6 breaking migration, and version upgrades.",
+  "author": {
+    "name": "Omar Hanafy",
+    "url": "https://github.com/omar-hanafy"
+  },
+  "homepage": "https://github.com/omar-hanafy/dart_helper_utils#ai-coding-assistant-support",
+  "repository": "https://github.com/omar-hanafy/dart_helper_utils",
+  "license": "MIT",
+  "keywords": [
+    "dart",
+    "flutter",
+    "dart-helper-utils",
+    "extensions",
+    "debouncer",
+    "streams",
+    "utilities"
+  ]
+}

--- a/tooling/ai/dart-helper-utils/.codex-plugin/plugin.json
+++ b/tooling/ai/dart-helper-utils/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "dart-helper-utils",
+  "version": "6.0.3",
+  "description": "Package-specific skills for the dart_helper_utils Dart package: exact utility APIs (strings, maps, collections, dates, intl formatting), async timing tools (Debouncer, throttle, stream transformers), the v5-to-v6 breaking migration, and version upgrades.",
+  "author": {
+    "name": "Omar Hanafy",
+    "url": "https://github.com/omar-hanafy"
+  },
+  "homepage": "https://github.com/omar-hanafy/dart_helper_utils#ai-coding-assistant-support",
+  "repository": "https://github.com/omar-hanafy/dart_helper_utils",
+  "license": "MIT",
+  "keywords": [
+    "dart",
+    "flutter",
+    "dart-helper-utils",
+    "extensions",
+    "debouncer",
+    "streams",
+    "utilities"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Dart Helper Utils",
+    "shortDescription": "Skills for the dart_helper_utils Dart utility package",
+    "developerName": "Omar Hanafy",
+    "category": "Developer Tools"
+  }
+}

--- a/tooling/ai/dart-helper-utils/README.md
+++ b/tooling/ai/dart-helper-utils/README.md
@@ -1,0 +1,86 @@
+# dart-helper-utils agent plugin
+
+Package-specific AI coding-assistant support for the
+[dart_helper_utils](https://pub.dev/packages/dart_helper_utils) Dart package,
+installable in Claude Code and OpenAI Codex from this repository. It ships
+skills only - no hooks, no MCP servers, no telemetry, no network access.
+
+## Capabilities
+
+| Skill | Use it for |
+|---|---|
+| `use-dart-helper-utils` | Correct member names and semantics across the utility surface (maps, strings, casing, MIME, collections, numbers, dates, intl, URI) plus the one-import re-export model |
+| `async-with-dart-helper-utils` | Debouncer/throttle lifecycle, stream transformers (rateLimit, bufferCount, asPausable, retry), Future minWait/timeoutOrNull/retry, bounded concurrency, and their ordering/disposal traps |
+| `migrate-dart-helper-utils-v5-to-v6` | The v6 breaking migration (conversion moved to convert_object, renames, removals, silent behavior changes) |
+| `upgrade-dart-helper-utils` | Version detection and hop sequencing for any upgrade (v2/v3/v4/v5/v6, patch bumps) |
+
+## Install in Claude Code
+
+```
+/plugin marketplace add omar-hanafy/dart_helper_utils
+/plugin install dart-helper-utils@dart-helper-utils-tools
+```
+
+Skills auto-trigger on relevant work; invoke one explicitly with
+`/dart-helper-utils:use-dart-helper-utils` (same pattern for the others).
+
+## Install in OpenAI Codex (CLI)
+
+```
+codex plugin marketplace add omar-hanafy/dart_helper_utils
+codex plugin add dart-helper-utils@dart-helper-utils-tools
+```
+
+Start a NEW Codex session afterwards; bundled skills load at session start.
+The Codex IDE extension does not support plugins; there, ask the
+`$skill-installer` skill to install the skills from this repository's
+`tooling/ai/dart-helper-utils/skills/` directory instead.
+
+## Example prompts
+
+- "Debounce this search field with dart_helper_utils and make sure nothing
+  leaks when the widget is disposed."
+- "Read `db.pool.size` from this nested config map, defaulting to 10."
+- "We are upgrading dart_helper_utils from 5.4.2 to 6.x - audit the repo and
+  do the migration."
+
+## Updating and uninstalling
+
+- Claude Code: `/plugin marketplace update dart-helper-utils-tools`, and
+  uninstall with `/plugin uninstall dart-helper-utils@dart-helper-utils-tools`
+  (or remove the marketplace with
+  `/plugin marketplace remove dart-helper-utils-tools`).
+- Codex: `codex plugin marketplace update dart-helper-utils-tools`, remove
+  with `codex plugin remove dart-helper-utils@dart-helper-utils-tools`
+  (removing the marketplace also removes its plugins).
+
+## Permissions and trust
+
+The plugin contains markdown skills only. Skills instruct the agent to run
+ordinary Dart tooling (`dart analyze`, `dart test`, `grep`) in YOUR project
+with your normal approval flow; the plugin itself executes nothing and
+phones home to nothing.
+
+## Compatibility
+
+- Documents dart_helper_utils 6.x (plugin version tracks the package
+  version). The migration/upgrade skills additionally cover 1.x-5.x
+  codebases.
+- Claude Code with plugin support; Codex CLI 0.44+ (plugin + marketplace
+  commands).
+
+## Maintainers
+
+- One canonical skills tree (`skills/`) is shared by both manifests
+  (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`); both
+  manifest versions MUST equal the `pubspec.yaml` version.
+- `dart run tool/validate_agent_plugin.dart` (from the repo root) enforces
+  manifest/catalog/frontmatter consistency and runs in CI.
+- Validate locally against Claude:
+  `claude plugin validate .claude-plugin/marketplace.json --strict` (root)
+  and `claude plugin validate tooling/ai/dart-helper-utils --strict`.
+- Skill facts must match the source; when changing behavior in `lib/`,
+  update the affected skill/reference files in the same PR.
+- Any future BREAKING package release must ship its migration hop (a new
+  `migrate-dart-helper-utils-vX-to-vY` skill or an upgrade-skill hop entry)
+  before tagging.

--- a/tooling/ai/dart-helper-utils/skills/async-with-dart-helper-utils/SKILL.md
+++ b/tooling/ai/dart-helper-utils/skills/async-with-dart-helper-utils/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: async-with-dart-helper-utils
+description: Use when Dart/Flutter code needs debouncing, throttling, stream shaping, or bounded-concurrency async work with the dart_helper_utils package - search-input debounce, rate-limited event streams, Debouncer/DebouncedCallback/Throttler lifecycle and disposal, TimeUtils.debounce/throttle/runWithTimeout, stream bufferCount/window/rateLimit/asPausable/withLatestValue/retry/replaceOnError, StreamController safeAdd/safeClose, Future minWait/timeoutOrNull, retry with exponential backoff, waitConcurrency, or mapConcurrent.
+---
+
+# Async, timing, and streams with dart_helper_utils
+
+These APIs carry lifecycle and ordering semantics that agents reliably get
+wrong from memory (wrong names, wrong parameter names, missed disposal,
+wrong result ordering). Use the exact contracts below.
+
+## Choosing the right primitive
+
+| Need | Use |
+|---|---|
+| Collapse a burst into one trailing call (search input) | `TimeUtils.debounce(fn, duration)` or a `Debouncer` you manage |
+| At most one call per interval (scroll, resize) | `TimeUtils.throttle(fn, interval, trailing: ...)` |
+| Cap a STREAM's event rate | `stream.rateLimit(maxEvents, window)` - overflow events are DROPPED, not queued |
+| Batch stream events by count / by time | `bufferCount(n)` / `window(duration)` |
+| Hold stream events until ready | `stream.asPausable()` |
+| Late subscribers need the last value | `stream.withLatestValue()` |
+| Bound how many futures run at once | `thunks.waitConcurrency(concurrency: 5)` or `items.mapConcurrent(fn, parallelism: 3)` |
+| Retry a flaky async call | `(() => call()).retry(retries: 3)` |
+| Anti-flicker minimum spinner time | `future.minWait(duration)` |
+| Timeout as null instead of an exception | `future.timeoutOrNull(duration)` |
+
+## Debounce
+
+```dart
+final debounced = TimeUtils.debounce(
+  () => runSearch(query),          // FutureOr<void> Function()
+  const Duration(milliseconds: 300),
+  maxWait: const Duration(seconds: 2), // must be > delay when set
+  immediate: false,                    // true = leading edge
+);
+debounced();          // call it like a function
+await debounced.flush(); // run the pending action NOW
+debounced.cancel();   // drop the pending action
+debounced.dispose();  // REQUIRED cleanup (idempotent)
+```
+
+- Returned type is `DebouncedCallback` (`call`, `flush`, `cancel`,
+  `dispose`, `isRunning`, `isDisposed`).
+- For pause/resume, observability, or history, construct `Debouncer`
+  directly: `run(action)`, `flush()`, `tryFlush()`, `runIfNotPending()`,
+  `cancel()`, `reset()`, `pause()`, `resume()`, `dispose()`, plus
+  `stateStream` (broadcast `Stream<DebouncerState>`), `executionCount`,
+  `remainingTime`, `remainingMaxWait`, `isPaused`.
+- `Debouncer` validates `delay > 0`, `maxWait > delay`, and throws
+  `StateError` if used after `dispose()`. `stateStream` is closed by
+  `dispose()` - in Flutter, dispose in `State.dispose()`.
+
+## Throttle
+
+```dart
+final throttled = TimeUtils.throttle(
+  onScroll,                       // void Function()
+  const Duration(milliseconds: 200),
+  leading: true,                  // default
+  trailing: false,                // DEFAULT false: burst calls are DROPPED
+);
+throttled();
+throttled.cancel();   // drop pending trailing call
+throttled.dispose();  // REQUIRED cleanup
+```
+
+- Returned type is `ThrottledCallback` - NOT `ThrottledFunction`; `cancel`
+  and `dispose` are separate members and dispose is the terminal one.
+- Set `trailing: true` when the LAST call of a burst must run; the default
+  leading-only mode silently drops it.
+
+## Streams
+
+- `bufferCount(int count)` - emits `List<T>`; flushes the remainder on done;
+  throws `ArgumentError` when count <= 0.
+- `window(Duration)` - time-based batches.
+- `rateLimit(int maxEvents, Duration duration)` - positional args (there is
+  no `per:` parameter); events beyond the cap inside a window are DROPPED.
+- `asPausable()` returns `PausableStream<T>`: listen on `.stream`, control
+  with `pause()`/`resume()` (events are held with backpressure, not lost);
+  cleanup happens when the subscription on `.stream` is cancelled.
+- `withLatestValue()` - behavior-subject wrapper; internally broadcast.
+- Error recovery on `Stream<T>`: `replaceOnError({required T defaultValue})`
+  (emit default, then close) and `completeOnError()` (swallow, close).
+- RETRY TRAP: `stream.retry(...)` on an already-listened single-subscription
+  stream throws `StateError`. For single-subscription sources, retry the
+  FACTORY instead:
+
+```dart
+Stream<T> Function() make = () => openSocket();
+final resilient = make.retry(
+  retryCount: 3,                          // NOT "retries"
+  delayFactor: const Duration(seconds: 1), // exponential base
+  shouldRetry: (e) => e is SocketException, // NOT "retryIf"
+);
+```
+
+- `StreamController<T>` safety: `safeAdd(event)`/`safeAddError(e)` return
+  bool instead of throwing on a closed controller; `safeClose()`,
+  `safeAddAll(events, {throttleDuration})`, `safeAddStream(source)`,
+  `mergeStreams(list)`, `asBroadcast()`.
+
+## Futures and bounded concurrency
+
+- `future.minWait(duration)` and `future.timeoutOrNull(duration)`.
+- Retry is an extension on the FUNCTION type, and stream/future retry use
+  DIFFERENT parameter names:
+
+```dart
+final data = await (() => api.fetch()).retry(
+  retries: 3,                            // future version
+  delay: const Duration(seconds: 1),     // doubles each attempt (2^n)
+  retryIf: (e) => e is TimeoutException,
+);
+```
+
+- `waitConcurrency` lives on `Iterable<Future<T> Function()>` (thunks, so
+  starts can be gated), not on `Iterable<Future>`:
+
+```dart
+final tasks = urls.map((u) => () => fetch(u));
+final results = await tasks.waitConcurrency(concurrency: 5);
+```
+
+- `items.mapConcurrent(action, {parallelism = 1})` maps with a limit; note
+  `parallelism:` here vs `concurrency:` on waitConcurrency.
+- ORDERING TRAP: both `waitConcurrency` and `mapConcurrent` return results
+  in COMPLETION order, not input order. If order matters, carry the index:
+
+```dart
+final indexed = await items
+    .mapIndexed((i, e) => () async => (i, await process(e)))
+    .waitConcurrency(concurrency: 4);
+indexed.sortBy<num>((r) => r.$1);
+```
+
+- `TimeUtils.runWithTimeout(task: ..., timeout: ...)` is a SOFT deadline: on
+  timeout it completes with `TimeoutException` but the task keeps running in
+  the background with its late errors swallowed. Do not use it to cancel
+  work; pair it with a `Completer` if you must observe late completion.
+- Measurement helpers: `TimeUtils.executionDuration(task)`,
+  `executionDurations(tasks)`, `compareExecutionTimes(taskA:, taskB:)`,
+  `runPeriodically(interval:, onExecute: (timer, count) {...})`.
+
+## Step 0: Inspect the project first
+
+1. Resolved version: `grep -A2 'dart_helper_utils' pubspec.lock` (this skill
+   documents 6.x; TimeUtils.throttle had a DIFFERENT signature in 5.x).
+2. In Flutter, find where the enclosing State/BLoC disposes resources and
+   wire `dispose()` of any Debouncer/DebouncedCallback/ThrottledCallback
+   there; creating them per-build is a leak.
+
+## Verification
+
+- `dart analyze` the touched paths; run the project's tests.
+- For new debounce/throttle code, add a fake-async or short-real-delay test
+  that asserts the collapsed call count, and a test that `dispose()` is
+  reached (leaked timers keep test processes alive - a hanging test run is
+  the symptom).
+
+## Failure handling
+
+- "Stream has already been listened to" or a StateError naming the retry
+  extension: you retried a listened single-subscription stream - switch to
+  the factory form above.
+- Results in unexpected order after waitConcurrency/mapConcurrent: that is
+  the documented completion-order contract; index-tag as shown.
+- Undefined member errors: check the resolved version; 5.x names differ
+  (use the migrate-dart-helper-utils-v5-to-v6 skill).
+- For non-async utility APIs (strings, maps, dates, formatting), use the
+  use-dart-helper-utils skill.

--- a/tooling/ai/dart-helper-utils/skills/migrate-dart-helper-utils-v5-to-v6/SKILL.md
+++ b/tooling/ai/dart-helper-utils/skills/migrate-dart-helper-utils-v5-to-v6/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: migrate-dart-helper-utils-v5-to-v6
+description: Use when upgrading a project from dart_helper_utils 5.x or earlier to 6.x, or fixing compile errors after that bump - ConvertObject/toString1/ParsingException renames, altKeys to alternativeKeys, firstValueForKeys to tryGetRaw, removed Paginator/DoublyLinkedList/country data/StringSimilarity, httpFormat to httpDateFormat, flatJson to flatMap, TimeUtils.throttle signature change, percentile 0-100 range, delay methods, or helpers that moved to convert_object or package collection.
+---
+
+# Migrate dart_helper_utils v5 to v6
+
+v6 is a large breaking release: all conversion logic moved to the
+`convert_object` package (re-exported, so one DHU import still works),
+several features moved to standalone packages, and many members were
+renamed or removed. Source and target: any 5.x (and the same checklist
+covers 4.x code, which mostly compiled unchanged under 5.x) to 6.x.
+
+## Preconditions
+
+1. Clean git working tree; do the migration on a branch. Rollback is
+   discarding that branch - never reset user work without explicit
+   confirmation.
+2. Run the test suite BEFORE migrating and record the baseline.
+3. Confirm the current version: `grep -A2 'dart_helper_utils' pubspec.lock`.
+   Already >= 6.0.0 means only leftover compile errors need the tables here,
+   not the dependency change.
+
+## Detect usage (scope the work)
+
+```bash
+grep -rln "package:dart_helper_utils" lib/ test/
+# v5-only symbols that will break:
+grep -rnE "ConvertObject\.|ParsingException|toString1|altKeys|firstValueForKeys|firstElementForIndices|httpFormat|flatJson|makeEncodable|safelyEncodedJson|DoublyLinkedList|Paginator|InfinitePaginator|AsyncPaginator|StringSimilarity|similarityTo|compareWith|DHUCountry|DHUTimezone|convertTo<" lib/ test/
+# bare top-level conversion helpers (v5):
+grep -rnE "\b(toNum|toInt|toDouble|toBool|toDateTime|toUri|toList|toSet|toMap|toBigInt|toType|tryTo[A-Z][a-zA-Z]*)\(" lib/ test/
+```
+
+For a large codebase, delegate the sweep to a read-only search subagent and
+have it return the file list with per-symbol counts.
+
+## Ordered steps
+
+1. Bump the dependency: `dart_helper_utils: ^6.0.2` (SDK `^3.10.0`);
+   `dart pub get`. Solver conflicts usually mean an old SDK constraint or a
+   direct pin on pre-1.1 `convert_object`.
+2. Apply the mechanical renames from
+   [references/v5-to-v6-api-mapping.md](references/v5-to-v6-api-mapping.md).
+   Headlines: `ConvertObject.` to `Convert.`, `toString1` to
+   `Convert.string`, bare `toInt(x)` to `convertToInt(x)`,
+   `ParsingException` to `ConversionException` (context is `e.context`),
+   `altKeys:` to `alternativeKeys:`, `firstValueForKeys` to `tryGetRaw`,
+   `httpFormat` to `httpDateFormat`, `flatJson` to `flatMap`,
+   `makeEncodable`/`safelyEncodedJson` to `toJsonSafe()`/`toJsonString()`.
+3. Replace REMOVED features (each needs a decision, not a rename):
+   - Paginator/AsyncPaginator/InfinitePaginator: no v6 equivalent; move to
+     a pagination package or inline the logic.
+   - DoublyLinkedList: `doubly_linked_list` package.
+   - StringSimilarity/`similarityTo`/`compareWith`:
+     `string_search_algorithms` package (algorithm enum renamed, e.g.
+     `levenshteinDistance` to `levenshtein`).
+   - DHUCountry/DHUTimezone datasets: removed; use a dedicated data source.
+   - `obj.isInt`/`isDouble`/`isNull` object getters: standard Dart checks or
+     `tryConvertToInt(obj) != null`.
+   - `list.convertTo<T>()`: `convertToList<T>(list)` (Set keeps
+     `convertTo`).
+4. Fix duplicate-helper removals: `firstOrNull`, `groupBy`, `mapIndexed`,
+   `whereNotNull`, ... now come from the re-exported `package:collection`;
+   the same names keep working with ONE DHU import. Ambiguous-extension
+   errors mean a file imports both DHU and `collection` (or old DHU
+   leftovers) - keep a single provider per file.
+5. `dart analyze` and iterate until clean.
+
+## Behavior changes to audit (compile-clean but different at runtime)
+
+- `alternativeKeys` (all typed map getters) now picks the first NON-null
+  value; a present-but-null key no longer short-circuits. Audit sites that
+  relied on the old behavior; use `containsKey` to distinguish absence.
+- `tryToBool` returns null (not false) for unknown values; add `?? false`
+  where a false fallback was assumed.
+- Numeric parsing is LENIENT by default (commas, spaces, `(123)` as -123);
+  set `NumberOptions(strictParsing: true)` via `Convert.configure` to keep
+  strict v5 behavior.
+- URI parsing auto-detects emails/phones into mailto and tel URIs; disable
+  with `UriOptions(detectEmails: false, detectPhoneNumbers: false)`.
+- `toDateTime` now accepts numeric epochs (seconds or milliseconds by
+  magnitude).
+- `percentile` now takes 0-100 (v5 took 0-1): `values.percentile(0.5)`
+  must become `values.percentile(50)`.
+- `TimeUtils.throttle` signature changed from named `duration:`/`function:`
+  to positional `(func, interval, {leading, trailing, onError})` returning a
+  callable `ThrottledCallback` with `cancel`/`dispose`.
+- `TimeUtils.runWithTimeout` now completes with `TimeoutException` while the
+  task keeps running (late errors swallowed).
+- `tryRemoveWhere` now takes a predicate and actually removes.
+- `setIfMissing` checks key presence, not null values.
+- `getRandom` on an empty iterable throws `StateError`; `randomInRange`
+  validates min <= max.
+- `concatWithSingleList`/`concatWithMultipleList` return the non-empty side
+  when one side is empty.
+- Delay helpers are methods now: `2.secondsDelay()`, not `2.secDelay`
+  (a v4-to-v5 change that often surfaces here).
+
+## Cases requiring human judgment
+
+- Code that parsed `ParsingException` text or inspected `e.parsingInfo`:
+  rewrite against `ConversionException.context`/`fullReport()`.
+- Dynamic dispatch (`(x as dynamic).toInt()`): greps cannot find these;
+  rely on the recorded test baseline.
+- Heavy paginator usage: propose the replacement package and get agreement
+  before rewriting screens around it.
+
+## Validation
+
+- `dart analyze` clean, then the full test suite compared against the
+  pre-migration baseline.
+- Re-grep the v5-only symbol list above; zero hits expected.
+- Runtime spot-check any `alternativeKeys`, bool-parsing, and percentile
+  call sites (the silent behavior changes).
+
+## Before/after example
+
+```dart
+// v5
+final id = ConvertObject.toInt(json, mapKey: 'id');
+final name = ConvertObject.toString1(json['name']);
+final raw = json.firstValueForKeys('a', altKeys: ['b']);
+final when = date.httpFormat;
+final p = scores.percentile(0.9);
+try { ... } on ParsingException catch (e) { log(e.parsingInfo.toString()); }
+
+// v6
+final id = Convert.toInt(json, mapKey: 'id');
+final name = Convert.string(json['name']);
+final raw = json.tryGetRaw('a', alternativeKeys: ['b']);
+final when = date.httpDateFormat;
+final p = scores.percentile(90);
+try { ... } on ConversionException catch (e) { log(e.fullReport()); }
+```
+
+## Failure handling
+
+- If the project is on 4.x or older, the extra v4-era changes (paginator
+  lifecycle, delay methods) are already covered above; for v2/v3-era code
+  use the upgrade-dart-helper-utils skill to sequence hops.
+- If a symbol is in neither the mapping nor the removals, check the
+  package's migration_guides.md and CHANGELOG.md for the installed version
+  before inventing a replacement.

--- a/tooling/ai/dart-helper-utils/skills/migrate-dart-helper-utils-v5-to-v6/references/v5-to-v6-api-mapping.md
+++ b/tooling/ai/dart-helper-utils/skills/migrate-dart-helper-utils-v5-to-v6/references/v5-to-v6-api-mapping.md
@@ -1,0 +1,92 @@
+# dart_helper_utils v5 to v6 API mapping
+
+Verified against the repository's migration_guides.md and the 6.x source.
+
+## Conversion facade (moved to convert_object, re-exported by DHU 6)
+
+| v5 | v6 |
+|---|---|
+| `ConvertObject.toInt(...)` | `Convert.toInt(...)` (same mapKey/listIndex args) |
+| `ConvertObject.toString1(v)` | `Convert.string(v)` |
+| `ConvertObject.tryToX(...)` | `Convert.tryToX(...)` |
+| `ConvertObject.toEnum` / `tryToEnum` | `Convert.toEnum` / `tryToEnum` (`parser:` required) |
+
+## Top-level conversion functions (bare names gained a prefix)
+
+| v5 | v6 |
+|---|---|
+| `toString1(v)` / `tryToString(v)` | `convertToString(v)` / `tryConvertToString(v)` |
+| `toNum(v)` / `tryToNum(v)` | `convertToNum(v)` / `tryConvertToNum(v)` |
+| `toInt(v)` / `tryToInt(v)` | `convertToInt(v)` / `tryConvertToInt(v)` |
+| `toDouble(v)` / `tryToDouble(v)` | `convertToDouble(v)` / `tryConvertToDouble(v)` |
+| `toBigInt(v)` / `tryToBigInt(v)` | `convertToBigInt(v)` / `tryConvertToBigInt(v)` |
+| `toBool(v)` / `tryToBool(v)` | `convertToBool(v)` / `tryConvertToBool(v)` |
+| `toDateTime(v)` / `tryToDateTime(v)` | `convertToDateTime(v)` / `tryConvertToDateTime(v)` |
+| `toUri(v)` / `tryToUri(v)` | `convertToUri(v)` / `tryConvertToUri(v)` |
+| `toMap<K,V>(v)` / `tryToMap<K,V>(v)` | `convertToMap<K,V>(v)` / `tryConvertToMap<K,V>(v)` |
+| `toSet<T>(v)` / `tryToSet<T>(v)` | `convertToSet<T>(v)` / `tryConvertToSet<T>(v)` |
+| `toList<T>(v)` / `tryToList<T>(v)` | `convertToList<T>(v)` / `tryConvertToList<T>(v)` |
+| `toType<T>(v)` / `tryToType<T>(v)` | `convertToType<T>(v)` / `tryConvertToType<T>(v)` |
+
+## Exceptions
+
+| v5 | v6 |
+|---|---|
+| `ParsingException` | `ConversionException` |
+| `e.parsingInfo` | `e.context` (plus `e.fullReport()` for the verbose dump) |
+
+## Map / Iterable
+
+| v5 | v6 |
+|---|---|
+| `map.getString('k', altKeys: [...])` | `map.getString('k', alternativeKeys: [...])` (every typed getter) |
+| `map.firstValueForKeys('k', altKeys: a)` | `map.tryGetRaw('k', alternativeKeys: a)` (first NON-null wins) |
+| `iterable.firstElementForIndices(...)` | `tryGetX(i, alternativeIndices: [...])` typed getters |
+| `map.flatJson(...)` | `map.flatMap(...)` |
+| `map.makeEncodable` / `encodableCopy` | `map.toJsonSafe()` / `map.toJsonMap()` |
+| `map.safelyEncodedJson` / `encodedJsonString` | `map.toJsonString(indent: '  ')` / `map.encodeWithIndent` |
+| `list.convertTo<T>()` | `convertToList<T>(list)` (`Set.convertTo` unchanged) |
+| `iter.firstOrNull`, `lastOrNull`, `firstWhereOrNull`, `whereNotNull`, `mapIndexed`, `forEachIndexed`, `whereIndexed`, `groupBy` | same names from re-exported `package:collection` (no code change with a single DHU import) |
+| `iter.sortedDescending()` | `iter.sorted((a, b) => b.compareTo(a))` |
+| `iter.count(pred)` | `iter.where(pred).length` |
+| `map.isEqual(other)` | `const MapEquality().equals(map, other)` (deep: `DeepCollectionEquality`) |
+| `list.tryRemoveWhere(index)` | `list.tryRemoveWhere((e) => ...)` (now a predicate that removes) |
+
+## DateTime / numbers / strings
+
+| v5 | v6 |
+|---|---|
+| `date.httpFormat` | `date.httpDateFormat` |
+| `values.percentile(0.5)` | `values.percentile(50)` (0-100 range) |
+| `2.secDelay` / `2.delay()` | `2.secondsDelay()` (methods; v4-era change) |
+| `5.minDelay` | `5.minutesDelay()` |
+| `obj.isInt` / `obj.isDouble` / `obj.isNum` | `tryConvertToInt(obj) != null` etc. |
+| `obj.isNull` / `obj.isNotNull` | `obj == null` / `obj != null` |
+| `DHUBoolNullablelEx` (typo name) | `DHUBoolNullableEx` |
+| Roman numeral helpers | moved to convert_object (`42.toRomanNumeral()`, `'XLII'.asRomanNumeralToInt`) |
+| String to num/DateTime parsing helpers | convert_object (`convertToNum`, `Convert.toDateTime`) |
+
+## TimeUtils
+
+| v5 | v6 |
+|---|---|
+| `TimeUtils.throttle(duration: d, function: f)` | `TimeUtils.throttle(f, d, {leading = true, trailing = false, onError})` -> `ThrottledCallback` (call/cancel/dispose) |
+| (no debounce helper) | `TimeUtils.debounce(f, d, {maxWait, immediate, debugLabel})` -> `DebouncedCallback` |
+| `runWithTimeout` cancels hard | soft `TimeoutException`; task keeps running, late errors swallowed |
+
+## Removed entirely (replacement decisions)
+
+| Removed in v6 | Replacement |
+|---|---|
+| `Paginator`, `AsyncPaginator`, `InfinitePaginator`, `PaginationConfig`, `PaginationAnalytics` | pagination packages (e.g. infinite_scroll_pagination) or custom code |
+| `DoublyLinkedList`, `toDoublyLinkedList` | `doubly_linked_list` package |
+| `StringSimilarity`, `SimilarityAlgorithm`, `String.similarityTo`, `String.compareWith`, `StringSimilarityConfig` | `string_search_algorithms` package (`levenshteinDistance` is now `levenshtein`) |
+| `DHUCountry`, `DHUTimezone`, `CountrySearchService`, `getRawCountriesData`, `getTimezonesRawData`, `getTimezonesList` | dedicated data package or API |
+| `DatesHelper` static class | `DateTime` extensions (`date.isSameDayAs(other)`, ...) |
+
+## Kept with surprising semantics
+
+- `Iterable.intersect` still MERGES (union) - historical behavior preserved
+  deliberately; do not "fix" call sites.
+- `isNumeric`/`isAlphabet` are ASCII-only and trim whitespace; `isBool` is
+  case-insensitive and trims.

--- a/tooling/ai/dart-helper-utils/skills/upgrade-dart-helper-utils/SKILL.md
+++ b/tooling/ai/dart-helper-utils/skills/upgrade-dart-helper-utils/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: upgrade-dart-helper-utils
+description: Use when bumping the dart_helper_utils package version in a project or auditing an upgrade's impact - detecting the installed version, sequencing migration hops across v2/v3/v4/v5/v6, patch-level 6.0.x bumps, or answering "is it safe to upgrade dart_helper_utils".
+---
+
+# Upgrade dart_helper_utils across versions
+
+Version-aware audit. Determine the CURRENT resolved version first, apply
+only the hops that cross it, and verify with the project's own tests.
+
+## Step 1: Detect versions
+
+```bash
+grep -n "dart_helper_utils" pubspec.yaml     # declared constraint
+grep -A2 "  dart_helper_utils:" pubspec.lock # resolved version
+```
+
+If the resolved version already equals the target: report "no migration
+needed" and stop (do not invent work).
+
+## Hop table (apply in order, oldest first)
+
+| From | To | Size | What changes |
+|---|---|---|---|
+| 1.x | 2.x | small | `toDateWithFormat` to `toDateFormatted`; `dateFormat` became a method with optional locale; `firstDayOfWeek`/`lastDayOfWeek` became methods with `startOfWeek:`; `flatJson` to `flatMap`; `makeEncodable`/`safelyEncodedJson` to `encodableCopy`/`encodedJsonString` |
+| 2.x | 3.x | small | removed deprecated `String.toDateTime` (use `toDate`/`toDateFormatted`) and `DateTime.format` (use `formatted`) |
+| 3.x | 4.x | medium | paginators rebuilt on `BasePaginator` (lifecycle, transform caching, `CancelableOperation`); generic `delay()` replaced by unit methods (`2.secondsDelay()`); disposal became no-op instead of throwing |
+| 4.x/5.x | 6.x | LARGE | use the dedicated migrate-dart-helper-utils-v5-to-v6 skill (conversion moved to convert_object, renames, removals, behavior changes) |
+| 6.0.x | 6.0.y | none | patch releases are docs/tooling unless the CHANGELOG says otherwise - read it first |
+
+Shortcut when crossing several majors: paginator work in the 3-to-4 hop is
+WASTED if the target is 6.x (paginators were removed in v6) - go straight
+to choosing a pagination replacement. The same applies to
+`encodableCopy`/`encodedJsonString` (renamed again in v6 to
+`toJsonSafe`/`toJsonString`).
+
+## Step 2: Execute
+
+1. Update the pubspec constraint; `dart pub get` (or
+   `dart pub upgrade dart_helper_utils`).
+2. Work through ONLY the hops crossed, oldest first, using the hop table
+   and (for the v6 hop) the dedicated migration skill.
+3. `dart analyze` and run the full test suite; compare failures against the
+   pre-upgrade baseline (record it first).
+
+## Failure handling
+
+- Solver conflict: 6.x needs SDK `^3.10.0` and `convert_object ^1.1.0`;
+  a direct dependency pinning `convert_object <1.1` (or an old SDK) blocks
+  resolution.
+- Behavior differences that survive a clean compile (bool parsing,
+  `alternativeKeys`, percentile range) are catalogued in the
+  migrate-dart-helper-utils-v5-to-v6 skill's behavior-changes section.
+- If the installed or target version is NEWER than 6.0.x, this skill may
+  predate it: read the package CHANGELOG for entries above 6.0.2 and treat
+  any "breaking" bullet as its own hop.

--- a/tooling/ai/dart-helper-utils/skills/use-dart-helper-utils/SKILL.md
+++ b/tooling/ai/dart-helper-utils/skills/use-dart-helper-utils/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: use-dart-helper-utils
+description: Use when writing or reviewing Dart/Flutter code that uses the dart_helper_utils package - deep map utilities (flatMap, unflatten, getPath, setPath, deepMerge), string casing/slugify/masking/parseDuration/truncate, MIME filename checks, iterable chunks/windowed/partition/distinctBy, number stats and HTTP status helpers, DateTime and Duration extensions, intl formatting wrappers (formatAsReadableNumber, dateFormat, pluralize), Uri rebuild, or deciding between dart_helper_utils and direct collection/intl/convert_object imports.
+---
+
+# Use dart_helper_utils correctly
+
+dart_helper_utils (DHU) is a batteries-included utility package. One import
+exposes three layers, and agents reliably misattribute or misname members
+across them - use the exact names below instead of memory.
+
+## The one-import model
+
+`import 'package:dart_helper_utils/dart_helper_utils.dart';` gives you:
+
+1. DHU's own extensions and helpers (this skill).
+2. ALL of `package:collection` (`firstOrNull`, `groupBy`, `mapIndexed`,
+   `DeepCollectionEquality`, ...) - re-exported wholesale.
+3. ALL of `package:convert_object` (`Convert.toX`, map `getInt`/`tryGetString`
+   getters, `convertToList`, `.convert` fluent chains, `toJsonString`, ...).
+4. ONLY five intl symbols: `Bidi`, `BidiFormatter`, `DateFormat`, `Intl`,
+   `NumberFormat`. Anything else from intl needs a direct `package:intl` import.
+
+Consequences:
+
+- Do NOT add `collection` or `convert_object` imports next to a DHU import;
+  the DHU import already provides them and duplicate imports invite
+  ambiguous-extension errors with pre-6 DHU code.
+- Conversion questions (getInt, fromJson factories, ConvertConfig, enum
+  parsing) belong to convert_object. If the convert-object plugin is
+  installed, its parse-with-convert-object skill is the deeper source.
+
+## Step 0: Inspect the project first
+
+1. Resolved version: `grep -A2 'dart_helper_utils' pubspec.lock`. This skill
+   documents 6.x. For 5.x-or-older projects, use the
+   migrate-dart-helper-utils-v5-to-v6 skill before writing new code.
+2. Match existing style: `grep -rn "dart_helper_utils" lib/ | head` to see how
+   the project already uses it; do not mix idioms in one file.
+
+## Exact names agents get wrong (verified against source)
+
+| Task | WRONG guesses | Actual API |
+|---|---|---|
+| Dot-path read/write | `getNested`/`setNested` | `map.getPath('db.host')`, `map.setPath('db.port', 5432)` (String-keyed maps; `items[0].id` bracket indices supported) |
+| Nested to flat and back | `unflatMap` | `map.flatMap({delimiter, excludeArrays})` and `map.unflatten({delimiter, parseIndices})` |
+| Raw multi-key lookup | `altKeys:` | `map.tryGetRaw('id', alternativeKeys: ['userId', 'uid'])` (first NON-null wins; from convert_object 1.1+) |
+| Fixed-size chunks | `chunked(2)` | `iterable.chunks(2)` |
+| Sliding windows | - | `windowed(3, step: 1, partials: false)` |
+| Split by predicate | - | `partition(pred)` returns a `(List<E>, List<E>)` record (matching, rest) |
+| Parse "1h 30m" | `toDuration()` | `'1h 30m'.parseDuration()` - ONLY clock (`HH:mm:ss`, `mm:ss`) and token (`2d 3h 4m 5s`) formats; no ISO-8601, no bare numbers; throws `FormatException` |
+| HTTP date header | `httpFormat` (v5) | `dateTime.httpDateFormat` (getter, RFC-1123) |
+| Retry delay for status | `suggestedRetryDelay` | `statusCode.statusCodeRetryDelay` (408 5s, 429 1m, 503 5m, 504 10s; zero for non-retryable) |
+| UUID check | `isValidUuid` | `'...'.isUuid` (getter) |
+
+## Casing, slugify, masking (all on String)
+
+- Casing members are GETTERS, not methods: `toCamelCase`, `toPascalCase`,
+  `toSnakeCase`, `toKebabCase`, `toTitleCase`, `toScreamingSnakeCase`,
+  `toDotCase`, `toWords`, `capitalizeFirstLetter`, and more.
+- `slugify()` is a method (`separator` param). ASCII-only: non-ASCII letters
+  are DROPPED, not transliterated - do not use it for i18n slugs.
+- `maskEmail` (getter) keeps the first two chars of the local part
+  (`'johndoe@gmail.com'` becomes `'jo****@gmail.com'`); returns the original
+  string unchanged when it is not a valid email.
+- `truncate(10)` appends the `'...'` suffix ON TOP of the length (result is up
+  to `length + suffix.length` chars) and only when the string is longer than
+  `length`.
+- MIME checks are filename/extension based getters on `String?`: `isImage`,
+  `isVideo`, `isPDF`, `isJSON`, ... They do not read file contents unless you
+  pass `headerBytes` to `mimeType()`.
+
+## Map and collection semantics worth knowing
+
+- `deepMerge(other)`: recursive for nested String-keyed maps; `other` wins on
+  conflicts; returns a NEW map.
+- `setIfMissing` checks key PRESENCE - it will not overwrite an existing key
+  even when its value is null.
+- `distinctBy(keySelector)`: pass `equals` and `hashCode` TOGETHER or neither;
+  supplying only one throws `ArgumentError`.
+- `getRandom()` throws `StateError` on an empty iterable; use `tryGetRandom()`
+  on nullable iterables.
+- Stats (`mean`, `median`, `percentile`, `standardDeviation`) exist on
+  `Iterable<num>` directly; `percentile(90)` takes the 0-100 range (v6 change
+  from 0-1).
+
+## Dates and durations
+
+- `date.isBetween(start, end)` is start-INclusive, end-EXclusive by default.
+- `daysInMonth` returns a full CALENDAR GRID (padded to whole Mon-Sun weeks),
+  not just the month's days - use `lastDayOfMonth.day` for the day count.
+- `addBusinessDays(n)` skips weekends (negative n supported).
+- `firstDayOfWeek()`/`lastDayOfWeek()` are methods with a
+  `startOfWeek: DateTime.monday` default.
+- Duration: `toClockString()` gives `HH:mm:ss`; `toHumanShort()` gives
+  `1h 3m 4s`; `2.secondsDelay()` and `duration.delayed()` schedule futures.
+
+## Intl wrappers
+
+- `1234567.89.formatAsReadableNumber(trimTrailingZeros: true)`,
+  `formatAsCurrency`, `formatAsCompact`, `formatAsPercentage` on num.
+- `dateTime.format('yMMMd')` plus ~30 `formatAsX` shortcuts
+  (`formatAsyMMMMd`, `formatAsEEEE`, ...).
+- `'string'.dateFormat([locale])` returns a `DateFormat` for that string.
+- `count.pluralize(other: 'items', one: 'item')` and
+  `'name'.genderSelect(...)` wrap Intl.
+
+## Verification
+
+After edits: `dart analyze` the touched paths and run the project's tests.
+When you used a member from the table above, confirm it resolves (analyzer
+errors on undefined members mean a wrong name or a pre-6 DHU version).
+
+## Failure handling
+
+- Undefined-member analyzer errors on names from this skill: check the
+  resolved package version first (`pubspec.lock`); 5.x has different names
+  (see the migrate-dart-helper-utils-v5-to-v6 skill).
+- Ambiguous-extension errors: the file probably imports `collection`,
+  `convert_object`, or an old DHU alongside the DHU import - keep exactly one
+  provider per file.
+- Anything about debouncing, throttling, streams, or bounded-concurrency
+  futures: use the async-with-dart-helper-utils skill; those APIs have
+  lifecycle rules this skill does not cover.
+
+## Full API tables
+
+For the complete per-domain member lists (strings, casing, MIME, maps,
+iterables, numbers/HTTP/stats, dates, durations, URI, intl, bool, globals,
+constants), read
+[references/api-quick-reference.md](references/api-quick-reference.md).
+
+## When NOT to use this package
+
+- One trivial helper in a project that does not already depend on DHU: prefer
+  plain Dart or the focused package (`collection`, `intl`) instead of adding a
+  broad dependency.
+- Type conversion only: depend on `convert_object` directly; DHU re-exports it
+  but pulls in more.

--- a/tooling/ai/dart-helper-utils/skills/use-dart-helper-utils/references/api-quick-reference.md
+++ b/tooling/ai/dart-helper-utils/skills/use-dart-helper-utils/references/api-quick-reference.md
@@ -1,0 +1,250 @@
+# dart_helper_utils API quick reference (v6.x)
+
+Exact member names by domain, verified against the 6.x source. Getters are
+marked (g); everything else is a method. Extensions on nullable receivers are
+marked `T?`.
+
+## Exports
+
+```dart
+export 'package:collection/collection.dart';          // wholesale
+export 'package:convert_object/convert_object.dart';  // wholesale
+// intl is SHOW-filtered to exactly:
+//   Bidi, BidiFormatter, DateFormat, Intl, NumberFormat
+```
+
+## Strings - general (`String` / `String?`)
+
+- Cleanup: `nullIfEmpty`(g), `nullIfBlank`(g), `removeEmptyLines`(g),
+  `toOneLine`(g), `removeWhiteSpaces`(g), `clean`(g),
+  `normalizeWhitespace()`, `words`(g), `lines`(g).
+- Encoding: `base64Encode()`, `base64Decode({bool? allowMalformed})`.
+- `slugify({String separator = '-'})` - ASCII only, drops non-ASCII letters,
+  throws `ArgumentError` on empty separator.
+- `parseDuration()` - clock `HH:mm:ss`/`mm:ss` (minutes/seconds < 60) or
+  tokens `2d 3h 4m 5s` (units d/h/m/s, case-insensitive, leading `-`
+  negates); anything else throws `FormatException`. Any `:` in the string
+  selects the clock parser.
+- On `String?`: `isEmptyOrNull`(g)/`isBlank`(g), `isNotEmptyOrNull`(g),
+  `toCharArray()`, `insert(index, str)`, `isPalindrome`(g),
+  `isAlphanumeric`(g), `hasSpecialChars`(g), `startsWithNumber`(g),
+  `containsDigits`(g), `isValidUsername`(g), `isValidCurrency`(g),
+  `isValidPhoneNumber`(g), `isValidEmail`(g), `isValidIp4`(g),
+  `isValidUrl`(g), `isNumeric`(g) (ASCII digits only), `isAlphabet`(g),
+  `hasCapitalLetter`(g), `isBool`(g),
+  `hasMatch(pattern, {multiLine, caseSensitive, unicode, dotAll})`,
+  `equalsIgnoreCase(other)`, `removeSurrounding(delimiter)`,
+  `replaceAfter`/`replaceBefore`, `orEmpty`(g), `ifEmpty(action)`,
+  `lastIndex`(g), `limitFromEnd(n)`/`limitFromStart(n)`,
+  `truncate(int length, {String suffix = '...'})`,
+  `wrapString({wordCount, wrapEach, delimiter})`.
+- `isUuid`(g), `maskEmail`(g),
+  `mask({visibleStart = 0, visibleEnd = 0, char = '*'})`.
+
+## Casing (`String`, ALL getters except noted)
+
+`toWords`, `toPascalCase`, `toTitleCase`, `toCamelCase`, `toSnakeCase`,
+`toKebabCase`, `toScreamingSnakeCase`, `toScreamingKebabCase`,
+`toPascalSnakeCase`, `toPascalKebabCase`, `toTrainCase` (same output as
+`toPascalKebabCase`), `toCamelSnakeCase`, `toCamelKebabCase`, `toDotCase`,
+`toFlatCase`, `toScreamingCase`, `capitalizeFirstLetter`,
+`lowercaseFirstLetter`, `capitalizeFirstLowerRest`, `toTitle` (keeps
+`-`/`_` delimiters, unlike `toTitleCase`). On `String?`:
+`tryToLowerCase()`, `tryToUpperCase()`.
+
+`toTitleCase` lowercases ~70 exception words (a, the, of, ...) inside the
+title; `toTitle` does not.
+
+## MIME checks (`String?`, filename/extension based, all getters)
+
+- Base: `mimeType({List<int>? headerBytes})`.
+- Video: `isVideo`, `isMP4`, `isMOV`, `isAVI`, `isWMV`, `isMKV`, `isWebM`,
+  `isFLV`.
+- Image: `isImage`, `isPNG`, `isJPEG`/`isJPG`, `isSVG`, `isGIF`, `isWebP`,
+  `isBMP`, `isTIFF`/`isTIF`, `isHEIC`, `isHEIF`, `isIcon`, `isICO`, `isICNS`.
+- Documents: `isPDF`, `isDOCX`, `isDOC` (alias of `isDOCX`), `isExcel`,
+  `isXLSX`, `isXLS`, `isPowerPoint`, `isPPTX`, `isPPT`, `isTXT`,
+  `isMarkdown`, `isRTF`.
+- Audio: `isAudio`, `isMP3`, `isWAV`, `isAAC`, `isFLAC`, `isOGG`, `isAIFF`.
+- Archive: `isArchive`, `isZIP`, `isRAR`, `is7Z`, `isTAR`, `isGZIP`/`isGZ`,
+  `isDeb`, `isISO`.
+- Code: `isHTML`, `isCSS`, `isJSON`, `isXML`, `isJavaScript`, `isTypeScript`,
+  `isPython`, `isJAVA`, `isPHP`, `isCSharp`, `isCpp`, `isC`, `isGo`,
+  `isRuby`, `isSwift`, `isKotlin`.
+- Fonts: `isFont`, `isTTF`, `isOTF`, `isWOFF`, `isWOFF2`, `isEOT`.
+  Contacts: `isContact`.
+
+## Maps
+
+- `Map<K, V>`: `swapKeysWithValues()`, `setIfMissing(key, value)` (checks
+  key PRESENCE, keeps existing null values), `keysWhere(condition)`,
+  `mapValues<V2>(transform)`, `filter((k, v) => bool)`.
+- `Map<K, V>?`: `isPrimitive()`, `isEmptyOrNull`(g), `isNotEmptyOrNull`(g).
+- String-keyed `Map<K extends String, V>`:
+  - `flatMap({delimiter = '.', excludeArrays = false})` - flattens nested
+    maps AND lists (indices become path segments); circular-ref safe.
+  - `unflatten({delimiter = '.', parseIndices = true})` - inverse.
+  - `deepMerge(Map<String, Object?> other)` - recursive, other wins,
+    returns a new map.
+  - `getPath(path, {delimiter = '.', parseIndices = true})` - supports
+    `items[0].id`; null on miss.
+  - `setPath(path, value, {delimiter = '.', parseIndices = true})` - creates
+    intermediate maps/lists, pads lists with nulls, returns bool success.
+- Typed getters (`getInt`, `tryGetString`, `getList<T>`, ...) come from
+  convert_object; `tryGetRaw(key, alternativeKeys: [...])` returns the first
+  NON-null raw value.
+
+## Iterables
+
+- `Iterable<E>`: `chunks(size)`, `windowed(size, {step = 1,
+  partials = false})`, `partition(pred)` -> `(List<E>, List<E>)` record,
+  `pairwise()` -> `List<(E, E)>`, `intersperse(element)`,
+  `associate<K2, V>(keySelector, [valueSelector])`,
+  `distinctBy<R>(keySelector, {equals, hashCode, isValidKey})` (equals and
+  hashCode go together), `subtract(other)`, `find(predicate)`,
+  `takeOnly(n)`, `drop(n)`, `firstHalf()`, `secondHalf()`, `halfLength`(g),
+  `swap(i, j)`, `getRandom([seed])` (throws on empty), `containsAll(other)`,
+  `filter`/`filterNot` (skip nulls), `orEmpty()`,
+  `concatWithSingleList`/`concatWithMultipleList` (return the non-empty side
+  when one side is empty), `toListConverted<R>()`/`toSetConverted<R>()`,
+  `mapConcurrent<R>(action, {parallelism = 1})` (async; COMPLETION order).
+- `Iterable<E>?`: `of(index)` (bounds-safe), `isEmptyOrNull`(g),
+  `firstOrDefault(default)`/`lastOrDefault(default)`, `tryGetRandom([seed])`,
+  `isEqual(other)` (deep), `totalBy(selector)`.
+- `List<E>?`: `tryRemoveAt(i)`, `indexOfOrNull(e)`,
+  `indexWhereOrNull(test, [start])`, `tryRemoveWhere(predicate)`.
+- SDK/`collection` provides `firstOrNull`, `firstWhereOrNull`, `groupBy`,
+  `mapIndexed`, `sorted`, ... via the re-export; DHU does not duplicate them.
+
+## Numbers
+
+- HTTP status on `num?` (all getters): `isSuccessCode` (200-299),
+  `isOkCode`, `isCreatedCode`, `isNoContentCode`, `isClientErrorCode`,
+  `isServerErrorCode`, `isRedirectionCode`, `isAuthenticationError`
+  (401/403), `isValidationError` (422), `isRateLimitError` (429),
+  `isTimeoutError` (408/504), `isConflictError` (409), `isNotFoundError`,
+  `isRetryableError` (408/429/503/504), `statusCodeRetryDelay` (408 5s,
+  429 1m, 503 5m, 504 10s, else zero unless retryable),
+  `toHttpStatusMessage`, `toHttpStatusUserMessage`, `toHttpStatusDevMessage`.
+- `num?`: `tryToInt()`, `tryToDouble()`,
+  `percentage(total, {allowDecimals = true})`, `isZeroOrNull`(g),
+  `asBool`(g) (> 0), `toDecimalString(places, {keepTrailingZeros})`.
+- `num`: `numberOfDigits`(g), `removeTrailingZero`(g), `half`(g)/`third`(g)/
+  `fourth`(g)/`tenth`(g), `getRandom`(g), `random([seed])`,
+  `asGreeks([zerosFractionDigits, fractionDigits])`,
+  `toFileSize({decimals = 2})`, `secondsDelay([callback])` (+ days/hours/
+  minutes/milliseconds variants), `asSeconds`(g) (+ asMilliseconds/
+  asMinutes/asHours/asDays -> Duration), `sqrt()`, `until(end, {step = 1})`,
+  `safeDivide(divisor, {...})`, `roundToNearestMultiple(m)`/
+  `roundUpToMultiple(m)`/`roundDownToMultiple(m)`,
+  `isBetween(min, max, {inclusive = true})`,
+  `toPercent({fractionDigits = 2})`,
+  `isApproximatelyEqual(other, {tolerance = 0.01})`,
+  `scaleBetween(min, max)`, `toFractionString()`, `isInteger`(g),
+  `toOrdinal({asWord = false, includeAnd = false})` (21st / twenty-first;
+  negatives throw).
+- `int`: `inRangeOf(min, max)`, `factorial()`, `gcd(other)`, `lcm(other)`,
+  `isPrime()`, `primeFactors()`, `isPerfectSquare()`, `isPerfectCube()`,
+  `isFibonacci()`, `isPowerOf(base)`, `toBinaryString()`, `toHexString()`,
+  `bitCount()`, `isDivisibleBy(d)`, `squared`(g)/`doubled`(g)/`tripled`(g).
+- Stats on `Iterable<num>` (and int/double variants): `mean`(g),
+  `median`(g), `mode`(g), `variance`(g), `standardDeviation`(g),
+  `percentile(double p)` with p in 0-100. `Iterable<num?>?.total`(g) treats
+  null as 0. Static twins on `NumbersHelper` (`safeDivide`, `mean`,
+  `median`, `percentile(values, p)`, `gcd`, `isPerfectSquare`).
+- Top-level: `randomInRange(min, max, [seed])` (inclusive; throws when
+  min > max).
+
+## Dates (`DateTime` / `DateTime?`)
+
+- Formatting: `httpDateFormat`(g) (RFC-1123), `toUtcIso`(g), `toIso`(g),
+  `format(pattern, [locale])`, `dateFormatUtc(pattern, [locale])`, ~30
+  `formatAsX([locale])` shortcuts (`formatAsyMMMMd`, `formatAsEEEE`,
+  `formatAsMMMEd`, `formatAsHms`, ...; note the odd casings `formatASyQQQ`
+  and `formatAsyQQQQ`). On `DateTime?`: `tryFormat(format)`.
+- Navigation: `startOfDay`(g)/`startOfMonth`(g)/`startOfYear`(g),
+  `tomorrow`(g)/`yesterday`(g)/`dateOnly`(g), `previousDay`(g)/`nextDay`(g),
+  `previousWeek`(g)/`nextWeek`(g), `firstDayOfMonth`(g)/`lastDayOfMonth`(g),
+  `previousMonth`(g)/`nextMonth`(g),
+  `firstDayOfWeek({startOfWeek = DateTime.monday})`,
+  `lastDayOfWeek({startOfWeek = DateTime.monday})`,
+  `daysInMonth`(g) - CALENDAR GRID padded to whole Mon-Sun weeks.
+- Arithmetic: `+`/`-` with Duration, `addDays(n)`...`addMicroseconds(n)`,
+  `subtractDays(n)`..., `addOrSubtractYears(n)`...,
+  `addBusinessDays(n)` (skips weekends, negatives ok), `min(other)`/
+  `max(other)`, `roundTo(Duration)`/`floorTo`/`ceilTo`, `clampBetween(a, b)`.
+- Queries: `isToday`(g), `isTomorrow`(g), `isYesterday`(g), `isPast`(g),
+  `isPresent`(g), `isInPastWeek`(g), `isInThisMonth`(g), `isLeapYear`(g),
+  `isWeekend`(g)/`isWeekday`(g), `isSameDayAs(other)`/`isSameWeekAs`/
+  `isSameHourAs`, `isAtSameYearAs(other)`...`isAtSameMicrosecondAs`,
+  `isBetween(start, end, {inclusiveStart = true, inclusiveEnd = false,
+  ignoreTime = false, normalize = false})`, `passedDuration`(g)/
+  `remainingDuration`(g), `passedDays`(g)/`remainingDays`(g),
+  `daysDifferenceTo([other])`, `daysUpTo(end)` (DST-aware iterable),
+  `calculateAge()` -> `({int years, int months, int days})` record.
+- On `num`: `toFullMonthName`(g), `toSmallMonthName`(g),
+  `toFullDayName`(g)/`toSmallDayName`(g) (ISO 1 = Monday),
+  `isCurrentYear`(g)/`isCurrentMonth`(g)/`isCurrentDay`(g),
+  `isBetweenMonths(start, end)`.
+
+## Durations
+
+`fromNow`(g), `ago`(g), `toClockString()` (`HH:mm:ss`), `toHumanShort()`
+(`1h 3m 4s`), `delayed<T>([computation])`.
+
+## Uri
+
+`domainName`(g), `rebuild({schemeBuilder, hostBuilder, portBuilder,
+pathBuilder, pathSegmentsBuilder, queryBuilder, queryParametersBuilder,
+fragmentBuilder, userInfoBuilder})` (segment builders beat string builders),
+`withQueryParameters(map)` (replaces), `mergeQueryParameters(map)`
+(incoming wins), `removeQueryParameters(keys)`, `appendPathSegment(s)`,
+`appendPathSegments(list)`, `normalizeTrailingSlash({trailingSlash = true})`.
+Iterable query values expand to repeated keys (`?ids=1&ids=2`).
+
+## Bool / Object / globals
+
+- `bool`: `toggled`(g). `bool?`: `isTrue`(g), `isFalse`(g) (non-null false
+  only), `val`(g) (null -> false), `binary`(g) (1/0), `binaryText`(g).
+- `Object?`: `isPrimitive()`.
+- Top-level: `isEqual(a, b)` (deep collection equality), `now`(g),
+  `currentMillisecondsSinceEpoch`(g), `randomBool([seed])`,
+  `randomInt(max, [seed])`, `randomDouble([seed])`,
+  `isValuePrimitive(v)`, `isTypePrimitive<T>()`.
+
+## Intl wrappers
+
+- num: `formatAsCurrency({locale, symbol = r'$', decimalDigits = 2,
+  customPattern})`, `formatAsSimpleCurrency`, `formatAsCompact`,
+  `formatAsCompactLong({explicitSign = false})`, `formatAsCompactCurrency`,
+  `formatAsDecimal`, `formatAsPercentage`, `formatAsDecimalPercent`,
+  `formatAsScientific`, `formatWithCustomPattern(pattern, {locale})`,
+  `formatAsReadableNumber({locale, decimalDigits = 2, groupingSeparator,
+  decimalSeparator, trimTrailingZeros = false})`.
+- String: `symbolCurrencyFormat`(g), `simpleCurrencyFormat`(g),
+  `compactCurrencyFormat`(g), `numberFormat({locale})` on `String?`,
+  `dateFormat([locale])` on `String?` -> `DateFormat`.
+- Plural/gender: `count.pluralize({required other, zero, one, two, few,
+  many, locale, ...})`, `count.getPluralCategory(...)`,
+  `'f'.genderSelect({required other, female, male, ...})`,
+  `'locale'.setAsDefaultLocale()`, `translate({...})`.
+- Bidi on String: `stripHtmlIfNeeded()`, `startsWithLtr`/`startsWithRtl`,
+  `hasAnyLtr`/`hasAnyRtl`, `isRtlLanguage([lang])`, `enforceRtlInHtml()`,
+  `enforceRtlIn()`, `enforceLtrInHtml()`, `enforceLtr()`,
+  `guessDirection({isHtml = false})`, `wrapWithSpan({...})`,
+  `wrapWithUnicode({...})`; constants `textDirectionLTR`,
+  `textDirectionRTL`, `textDirectionUNKNOWN`.
+
+## Constants (raw_data)
+
+`fullWeekdays`/`smallWeekdays`, `fullMonthsNames`/`smallMonthsNames`
+(1-indexed maps), `cssColorNamesToArgb`, `greekNumberSuffixes`,
+`oneSecond`/`oneMinute`/`oneHour`/`oneDay`, `httpStatusMessages`/
+`httpStatusUserMessage`/`httpStatusDevMessage`, regex constants
+(`regexValidEmail`, `regexValidIp4`, `regexValidHexColor`, ...).
+
+## Exceptions
+
+`RException` (`message`; `RException.steps()` thrown by `num.until` on a
+zero step). Conversion failures throw convert_object's
+`ConversionException` (read `e.fullReport()`).


### PR DESCRIPTION
## Summary
- Installable, repo-hosted AI coding-assistant plugin for Claude Code and OpenAI Codex: one canonical tree at `tooling/ai/dart-helper-utils/` with dual manifests and four package-specific skills (use-dart-helper-utils + full API quick reference, async-with-dart-helper-utils, migrate-dart-helper-utils-v5-to-v6 + v5-to-v6 mapping, upgrade-dart-helper-utils).
- Repo-root marketplace catalogs for both ecosystems (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`), marketplace name `dart-helper-utils-tools`.
- Maintainer guidance (`AGENTS.md`, `CLAUDE.md`) and deterministic validator `tool/validate_agent_plugin.dart` wired into CI (version sync, kebab-case, frontmatter, self-contained skills, path/secret markers, `.pubignore` coverage).
- README gains an "AI coding-assistant support" section with exact install commands; CHANGELOG 6.0.3; `.pubignore` excludes the plugin tree and maintainer files so the pub.dev archive stays plugin-free (verified via dry-run listing).
- No Dart API changes; version bump 6.0.2 -> 6.0.3 (patch).

## Validation
- `dart format` clean, `dart analyze` clean, 395/395 tests pass, validator passes, `dart pub publish --dry-run` clean archive (107 KB), pana 160/160 on a clean copy.
- `claude plugin validate --strict` passes for marketplace and plugin; local install + headless behavioral probes pass in BOTH Claude Code and Codex CLI (positive/GREEN, negative no-trigger, explicit invocation, empty-project failure handling); local test installs removed afterwards.