### PR TITLE
ci: restrict pub.dev publishing to tag pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,10 @@ on:
   push:
     tags:
       - 'dart_helper_utils-v*'
-  workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   publish:
     permissions:
+      contents: read
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## What

Removes the `workflow_dispatch` trigger from `.github/workflows/publish.yml`, leaving `push.tags` as the only trigger.

## Why

`workflow_dispatch` on a publish caller means **any identity with write access could publish `dart_helper_utils` from an arbitrary ref** — not just from a reviewed release tag. It also makes the OIDC token report a branch ref instead of the trusted tag, which is the documented cause of confusing trusted-publisher rejections.

This was inherited configuration, not something introduced recently. It surfaced while setting up the release lane for the new `stringo` package, which was scaffolded tag-only from the start.

## Both halves were open

The workflow trigger alone is not sufficient to publish — pub.dev must also authorize it. It did:

- **pub.dev admin → "Enable publishing from `workflow_dispatch` events"** was **checked**. It is now **unchecked** (verified after reload).
- This PR closes the GitHub half.

Either one alone still permits the path, so both had to change.

## Resulting posture

| Setting | State |
|---|---|
| Manual publishing (`pub login`) | disabled (already) |
| Publish from `push` events (tag) | enabled |
| Publish from `workflow_dispatch` | **disabled** |
| Tag pattern | `dart_helper_utils-v{{version}}` |

Tag pushes created by the reviewed `auto-release` workflow are now the **only** way to publish this package.

Recovery from a failed release is a new version through a PR — never a re-dispatch — which matches the existing immutable-tag policy.

## Safety

- No package payload change; `pubspec.yaml` is untouched, so `auto-release` will not create a tag on merge.
- `contents: read` moved onto the job alongside `id-token: write`, so the called reusable workflow receives both explicitly.
- 6.1.0 was published minutes ago through the tag path, so that path is proven working.